### PR TITLE
Add typed BullMQ job contracts, file staging, and move ops to queued workers

### DIFF
--- a/apps/webapp/src/lib/server/bullmq/fileStaging.ts
+++ b/apps/webapp/src/lib/server/bullmq/fileStaging.ts
@@ -1,0 +1,67 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { AwsS3StorageAdapter } from '@flystorage/aws-s3';
+import { FileStorage } from '@flystorage/file-storage';
+import { LocalStorageAdapter } from '@flystorage/local-fs';
+import { nanoid } from 'nanoid';
+
+import type { StagedFileData } from '@totallator/bullmq';
+
+import { serverEnv } from '../serverEnv';
+
+const STAGING_PREFIX = '__queue_staging';
+
+const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9._-]/g, '_');
+
+const getStorage = () => {
+	const address = serverEnv.IMPORT_DIR;
+
+	if (address.startsWith('s3://')) {
+		const bucketAndPrefix = address.replace('s3://', '');
+		const [bucket] = bucketAndPrefix.split('/');
+		if (!bucket) {
+			throw new Error('S3 bucket not correctly set');
+		}
+
+		const prefix = bucketAndPrefix.replace(`${bucket}/`, '');
+
+		if (
+			!serverEnv.S3_ACCESS_KEY_ID ||
+			!serverEnv.S3_SECRET_ACCESS_KEY ||
+			!serverEnv.S3_ACCESS_URL ||
+			!serverEnv.S3_REGION
+		) {
+			throw new Error('S3 environment variables not correctly set');
+		}
+
+		const client = new S3Client({
+			requestChecksumCalculation: serverEnv.S3_DISABLE_CHECKSUM
+				? 'WHEN_REQUIRED'
+				: 'WHEN_SUPPORTED',
+			responseChecksumValidation: serverEnv.S3_DISABLE_CHECKSUM
+				? 'WHEN_REQUIRED'
+				: 'WHEN_SUPPORTED',
+			credentials: {
+				accessKeyId: serverEnv.S3_ACCESS_KEY_ID,
+				secretAccessKey: serverEnv.S3_SECRET_ACCESS_KEY
+			},
+			endpoint: serverEnv.S3_ACCESS_URL,
+			region: serverEnv.S3_REGION
+		});
+
+		return new FileStorage(new AwsS3StorageAdapter(client, { bucket, prefix }));
+	}
+
+	return new FileStorage(new LocalStorageAdapter(address));
+};
+
+export const stageUploadedFile = async (file: File, idPrefix: string): Promise<StagedFileData> => {
+	const storage = getStorage();
+	const storageKey = `${STAGING_PREFIX}/${idPrefix}-${nanoid()}-${cleanName(file.name)}`;
+	await storage.write(storageKey, Buffer.from(await file.arrayBuffer()));
+
+	return {
+		storageKey,
+		originalName: file.name,
+		mimeType: file.type || 'application/octet-stream'
+	};
+};

--- a/apps/webapp/src/lib/server/bullmq/jobContracts.ts
+++ b/apps/webapp/src/lib/server/bullmq/jobContracts.ts
@@ -1,5 +1,5 @@
-export const WEBAPP_QUEUES = {
-	CRON: 'cron',
-	BACKGROUND: 'background',
-	LONG_RUNNING: 'long-running'
-} as const;
+export { TOTALLATOR_QUEUES as WEBAPP_QUEUES } from '@totallator/bullmq';
+export type {
+	CronControlJobData,
+	TotallatorWorkerJobMap as WorkerJobMap
+} from '@totallator/bullmq';

--- a/apps/webapp/src/lib/server/longProcess/state.ts
+++ b/apps/webapp/src/lib/server/longProcess/state.ts
@@ -266,3 +266,58 @@ export const getLongJobState = async (jobId: string) => {
 	const raw = await redis.get(getJobStateKey(jobId));
 	return parseJson<LongProcessJobState>(raw);
 };
+
+const getJobStateKeys = async (limit = 200) => {
+	const redis = getRedisClient();
+	let cursor = '0';
+	const keys: string[] = [];
+
+	do {
+		const [nextCursor, batch] = await redis.scan(
+			cursor,
+			'MATCH',
+			`${JOB_STATE_KEY_PREFIX}*:state`,
+			'COUNT',
+			100
+		);
+		cursor = nextCursor;
+		keys.push(...batch);
+		if (keys.length >= limit) {
+			break;
+		}
+	} while (cursor !== '0');
+
+	return keys.slice(0, limit);
+};
+
+export const getLatestLongJobState = async () => {
+	const redis = getRedisClient();
+	const keys = await getJobStateKeys();
+	if (keys.length === 0) {
+		return null;
+	}
+
+	const states = (await redis.mget(...keys))
+		.map((value) => parseJson<LongProcessJobState>(value))
+		.filter((value): value is LongProcessJobState => value !== null);
+
+	if (states.length === 0) {
+		return null;
+	}
+
+	states.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+	return states[0];
+};
+
+export const getLongProcessSnapshot = async () => {
+	const [lock, latestJob] = await Promise.all([getWriteLock(), getLatestLongJobState()]);
+	const activeJob = lock ? (await getLongJobState(lock.jobId)) ?? latestJob : null;
+
+	return {
+		writeLockEnabled: isWriteLockEnabled(),
+		locked: Boolean(lock),
+		lock,
+		activeJob,
+		latestJob
+	};
+};

--- a/apps/webapp/src/routes/(loggedIn)/admin/cron/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/admin/cron/+page.server.ts
@@ -9,7 +9,9 @@ import { cronJobUrlFilterSchema } from '@totallator/shared';
 
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { serverPageInfo } from '$lib/routes.server';
-import { addJob } from '$lib/server/bullmq/bullmqService';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 import type { Actions } from './$types';
 
@@ -70,7 +72,7 @@ export const actions: Actions = {
 		}
 
 		try {
-			await addJob('background', 'cron-control', {
+			await addTypedJob<WorkerJobMap, 'cron-control'>(WEBAPP_QUEUES.BACKGROUND, 'cron-control', {
 				action: 'trigger',
 				jobId: form.data.jobId,
 				userId: locals.user.id
@@ -102,7 +104,7 @@ export const actions: Actions = {
 		}
 
 		try {
-			await addJob('background', 'cron-control', {
+			await addTypedJob<WorkerJobMap, 'cron-control'>(WEBAPP_QUEUES.BACKGROUND, 'cron-control', {
 				action: 'toggle',
 				jobId: form.data.jobId,
 				isEnabled: form.data.isEnabled,

--- a/apps/webapp/src/routes/(loggedIn)/admin/cron/[id]/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/admin/cron/[id]/+page.server.ts
@@ -8,7 +8,9 @@ import { tActions } from '@totallator/business-logic';
 
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { serverPageInfo } from '$lib/routes.server';
-import { addJob } from '$lib/server/bullmq/bullmqService';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 import type { Actions, PageServerLoad } from './$types';
 
@@ -75,7 +77,7 @@ export const actions: Actions = {
 		}
 
 		try {
-			await addJob('background', 'cron-control', {
+			await addTypedJob<WorkerJobMap, 'cron-control'>(WEBAPP_QUEUES.BACKGROUND, 'cron-control', {
 				action: 'trigger',
 				jobId: form.data.jobId,
 				userId: locals.user.id
@@ -115,7 +117,9 @@ export const actions: Actions = {
 				modifiedBy: locals.user.id
 			});
 
-			await addJob('background', 'cron-control', { action: 'resync' });
+			await addTypedJob<WorkerJobMap, 'cron-control'>(WEBAPP_QUEUES.BACKGROUND, 'cron-control', {
+				action: 'resync'
+			});
 
 			return {
 				form,

--- a/apps/webapp/src/routes/(loggedIn)/autoImport/[id]/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/autoImport/[id]/+page.server.ts
@@ -10,6 +10,9 @@ import type { ImportFilterSchemaType } from '@totallator/shared';
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { urlGenerator } from '$lib/routes';
 import { serverPageInfo } from '$lib/routes.server';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (request) => {
 	authGuard(request);
@@ -105,9 +108,14 @@ export const actions = {
 		});
 	},
 	trigger: async (request) => {
-		await tActions.autoImport.trigger({
-			id: request.params.id
-		});
+		await addTypedJob<WorkerJobMap, 'auto-import-trigger'>(
+			WEBAPP_QUEUES.BACKGROUND,
+			'auto-import-trigger',
+			{
+				autoImportId: request.params.id,
+				triggeredByUserId: request.locals.user?.id
+			}
+		);
 	}
 };
 

--- a/apps/webapp/src/routes/(loggedIn)/backup/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/backup/+page.server.ts
@@ -7,6 +7,9 @@ import { tActions } from '@totallator/business-logic';
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { failWrapper } from '$lib/helpers/customEnhance';
 import { serverPageInfo, urlGeneratorServer as urlGenerator } from '$lib/routes.server';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (data) => {
 	authGuard(data);
@@ -50,11 +53,15 @@ export const load = async (data) => {
 };
 
 export const actions = {
-	refresh: async ({ request, locals }) => {
-		await tActions.backup.refreshList();
+	refresh: async () => {
+		await addTypedJob<WorkerJobMap, 'backup-refresh'>(
+			WEBAPP_QUEUES.BACKGROUND,
+			'backup-refresh',
+			{}
+		);
 	},
-	tidyBackups: async ({ request, locals }) => {
-		await tActions.backup.trimBackups();
+	tidyBackups: async () => {
+		await addTypedJob<WorkerJobMap, 'backup-trim'>(WEBAPP_QUEUES.BACKGROUND, 'backup-trim', {});
 	},
 	backup: async ({ request, locals }) => {
 		try {
@@ -64,7 +71,7 @@ export const actions = {
 			const backupNameValidated =
 				backupName && backupName.length > 0 ? backupName : 'Manual Backup';
 
-			await tActions.backup.storeBackup({
+			await addTypedJob<WorkerJobMap, 'backup-store'>(WEBAPP_QUEUES.BACKGROUND, 'backup-store', {
 				title: backupNameValidated,
 				compress: true,
 				createdBy: 'User',
@@ -84,7 +91,7 @@ export const actions = {
 			const backupNameValidated =
 				backupName && backupName.length > 0 ? backupName : 'Manual Backup';
 
-			await tActions.backup.storeBackup({
+			await addTypedJob<WorkerJobMap, 'backup-store'>(WEBAPP_QUEUES.BACKGROUND, 'backup-store', {
 				title: backupNameValidated,
 				compress: false,
 				createdBy: 'User',

--- a/apps/webapp/src/routes/(loggedIn)/backup/[id]/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/backup/[id]/+page.server.ts
@@ -7,6 +7,9 @@ import { tActions } from '@totallator/business-logic';
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { failWrapper } from '$lib/helpers/customEnhance';
 import { serverPageInfo, urlGeneratorServer as urlGenerator } from '$lib/routes.server';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (data) => {
 	authGuard(data);
@@ -99,11 +102,18 @@ export const actions = {
 		}
 
 		try {
-			await tActions.backup.restoreTrigger({
-				id,
-				includeUsers: false,
-				userId: locals.user?.id
-			});
+			await addTypedJob<WorkerJobMap, 'backup-restore'>(
+				WEBAPP_QUEUES.LONG_RUNNING,
+				'backup-restore',
+				{
+					backupId: id,
+					includeUsers: false,
+					userId: locals.user?.id
+				},
+				{
+					jobId: `backup-restore:${id}`
+				}
+			);
 		} catch (e) {
 			locals.global.logger('backup').error({
 				code: 'BCK_0004',
@@ -127,7 +137,9 @@ export const actions = {
 		}
 
 		try {
-			await tActions.backup.deleteBackup({ id });
+			await addTypedJob<WorkerJobMap, 'backup-delete'>(WEBAPP_QUEUES.BACKGROUND, 'backup-delete', {
+				backupId: id
+			});
 		} catch (e) {
 			locals.global
 				.logger('backup')

--- a/apps/webapp/src/routes/(loggedIn)/backup/import/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/backup/import/+page.server.ts
@@ -1,9 +1,11 @@
 import { redirect } from '@sveltejs/kit';
 import { nanoid } from 'nanoid';
 
-import { tActions } from '@totallator/business-logic';
-
 import { urlGenerator } from '$lib/routes.js';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { stageUploadedFile } from '$lib/server/bullmq/fileStaging';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const actions = {
 	import: async ({ request, locals }) => {
@@ -13,7 +15,15 @@ export const actions = {
 		const id = nanoid();
 
 		try {
-			await tActions.backup.importFile({ backupFile, id });
+			const staged = await stageUploadedFile(backupFile, `backup-import-${id}`);
+			await addTypedJob<WorkerJobMap, 'backup-import'>(
+				WEBAPP_QUEUES.LONG_RUNNING,
+				'backup-import',
+				{
+					backupId: id,
+					file: staged
+				}
+			);
 		} catch (e) {
 			locals.global.logger('backup').error({
 				code: 'BCK_0006',

--- a/apps/webapp/src/routes/(loggedIn)/files/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/files/+page.server.ts
@@ -6,6 +6,9 @@ import { fileFilterSchema } from '@totallator/shared';
 
 import { authGuard } from '$lib/authGuard/authGuardConfig';
 import { serverPageInfo } from '$lib/routes.server';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 import { extractAutocompleteFromTextFilter } from '$lib/server/helpers/filterConfigExtractor.js';
 
 export const _routeConfig = {
@@ -36,7 +39,11 @@ export const load = async (data) => {
 };
 
 export const actions = {
-	checkFiles: async (data) => {
-		await tActions.file.checkFilesExist();
+	checkFiles: async () => {
+		await addTypedJob<WorkerJobMap, 'file-check-exists'>(
+			WEBAPP_QUEUES.BACKGROUND,
+			'file-check-exists',
+			{}
+		);
 	}
 };

--- a/apps/webapp/src/routes/(loggedIn)/import/[id]/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/import/[id]/+page.server.ts
@@ -1,15 +1,20 @@
-import { redirect } from '@sveltejs/kit';
 import type { SingleServerRouteConfig } from 'skroutes';
 
 import { tActions } from '@totallator/business-logic';
 import { idSchema } from '@totallator/shared';
 
-import { urlGenerator } from '$lib/routes';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const actions = {
 	reprocess: async ({ params, locals }) => {
 		try {
-			await tActions.import.reprocess({ id: params.id });
+			await addTypedJob<WorkerJobMap, 'import-reprocess'>(
+				WEBAPP_QUEUES.BACKGROUND,
+				'import-reprocess',
+				{ importId: params.id }
+			);
 		} catch (e) {
 			locals.global.logger('import').error({
 				code: 'IMP_0003',
@@ -18,10 +23,15 @@ export const actions = {
 			});
 		}
 	},
-	triggerImport: async ({ params, locals }) => tActions.import.triggerImport({ id: params.id }),
+	triggerImport: async ({ params }) =>
+		addTypedJob<WorkerJobMap, 'import-trigger'>(WEBAPP_QUEUES.BACKGROUND, 'import-trigger', {
+			importId: params.id
+		}),
 	clean: async ({ params, locals }) => {
 		try {
-			await tActions.import.clean({ id: params.id });
+			await addTypedJob<WorkerJobMap, 'import-clean'>(WEBAPP_QUEUES.BACKGROUND, 'import-clean', {
+				importId: params.id
+			});
 		} catch (e) {
 			locals.global.logger('import').error({
 				code: 'IMP_0004',
@@ -29,19 +39,8 @@ export const actions = {
 				error: JSON.stringify(e, null, 2)
 			});
 		}
-
-		const importData = await tActions.import.get({
-			id: params.id
-		});
-
-		if (!importData.importInfo) {
-			return redirect(
-				302,
-				urlGenerator({ address: '/(loggedIn)/import', searchParamsValue: {} }).url
-			);
-		}
 	},
-	toggleAutoClean: async ({ params, locals }) => {
+	toggleAutoClean: async ({ params }) => {
 		const id = params.id;
 
 		const importData = await tActions.import.get({ id });
@@ -54,7 +53,7 @@ export const actions = {
 			data: { id, autoClean: !importData.importInfo.import.autoClean }
 		});
 	},
-	toggleAutoProcess: async ({ params, locals }) => {
+	toggleAutoProcess: async ({ params }) => {
 		const id = params.id;
 
 		const importData = await tActions.import.get({ id });

--- a/apps/webapp/src/routes/(loggedIn)/import/[id]/delete/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/import/[id]/delete/+page.server.ts
@@ -1,10 +1,12 @@
 import { redirect } from '@sveltejs/kit';
 import type { SingleServerRouteConfig } from 'skroutes';
 
-import { tActions } from '@totallator/business-logic';
 import { idSchema } from '@totallator/shared';
 
 import { urlGenerator } from '$lib/routes';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (data) => {
 	const parentData = await data.parent();
@@ -26,7 +28,9 @@ export const actions = {
 	default: async ({ params, locals }) => {
 		let deleted = false;
 		try {
-			await tActions.import.delete({ id: params.id });
+			await addTypedJob<WorkerJobMap, 'import-delete'>(WEBAPP_QUEUES.BACKGROUND, 'import-delete', {
+				importId: params.id
+			});
 			deleted = true;
 		} catch (e) {
 			locals.global.logger('import').error({

--- a/apps/webapp/src/routes/(loggedIn)/import/[id]/deleteLinked/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/import/[id]/deleteLinked/+page.server.ts
@@ -1,10 +1,12 @@
 import { redirect } from '@sveltejs/kit';
 import type { SingleServerRouteConfig } from 'skroutes';
 
-import { tActions } from '@totallator/business-logic';
 import { idSchema } from '@totallator/shared';
 
 import { urlGenerator } from '$lib/routes';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (data) => {
 	const parentData = await data.parent();
@@ -26,7 +28,11 @@ export const actions = {
 	default: async ({ params, locals }) => {
 		let deleted = false;
 		try {
-			await tActions.import.deleteLinked({ id: params.id });
+			await addTypedJob<WorkerJobMap, 'import-delete-linked'>(
+				WEBAPP_QUEUES.BACKGROUND,
+				'import-delete-linked',
+				{ importId: params.id }
+			);
 			deleted = true;
 		} catch (e) {
 			locals.global.logger('import').error({

--- a/apps/webapp/src/routes/(loggedIn)/import/[id]/forget/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/import/[id]/forget/+page.server.ts
@@ -1,16 +1,20 @@
 import { redirect } from '@sveltejs/kit';
 import type { SingleServerRouteConfig } from 'skroutes';
 
-import { tActions } from '@totallator/business-logic';
 import { idSchema } from '@totallator/shared';
 
 import { urlGenerator } from '$lib/routes';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const actions = {
 	default: async ({ params, locals }) => {
 		let deleted = false;
 		try {
-			await tActions.import.forgetImport({ id: params.id });
+			await addTypedJob<WorkerJobMap, 'import-forget'>(WEBAPP_QUEUES.BACKGROUND, 'import-forget', {
+				importId: params.id
+			});
 			deleted = true;
 		} catch (e) {
 			locals.global.logger('import').error({

--- a/apps/webapp/src/routes/(loggedIn)/import/create/+page.server.ts
+++ b/apps/webapp/src/routes/(loggedIn)/import/create/+page.server.ts
@@ -8,6 +8,10 @@ import { createImportSchema } from '@totallator/shared';
 
 import { authGuard } from '$lib/authGuard/authGuardConfig.js';
 import { urlGenerator } from '$lib/routes.js';
+import { addTypedJob } from '$lib/server/bullmq/bullmqService';
+import { stageUploadedFile } from '$lib/server/bullmq/fileStaging';
+import { WEBAPP_QUEUES } from '$lib/server/bullmq/jobContracts';
+import type { WorkerJobMap } from '$lib/server/bullmq/jobContracts';
 
 export const load = async (data) => {
 	authGuard(data);
@@ -47,8 +51,6 @@ export const actions = {
 			autoProcess: form.data.autoProcess
 		});
 
-		let newId: undefined | string = undefined;
-
 		try {
 			if (form.data.importMappingId) {
 				const result = await tActions.importMapping.getById({
@@ -69,16 +71,22 @@ export const actions = {
 				}
 			}
 
-			newId = await tActions.import.store({
-				data: form.data
+			const staged = await stageUploadedFile(form.data.file, 'import-store');
+
+			await addTypedJob<WorkerJobMap, 'import-store'>(WEBAPP_QUEUES.LONG_RUNNING, 'import-store', {
+				importType: form.data.importType,
+				importMappingId: form.data.importMappingId,
+				autoProcess: form.data.autoProcess,
+				autoClean: form.data.autoClean,
+				checkImportedOnly: form.data.checkImportedOnly,
+				file: staged
 			});
 
 			const duration = Date.now() - startTime;
 			locals.global.logger('imports').info({
 				code: 'WEB_IMP_014',
-				title: 'Import created successfully via web',
+				title: 'Import queued successfully via web',
 				userId: locals.user?.id,
-				importId: newId,
 				importType: form.data.importType,
 				autoProcess: form.data.autoProcess,
 				duration
@@ -100,31 +108,6 @@ export const actions = {
 			return message(form, 'Unknown Error Loading File', { status: 400 });
 		}
 
-		if (newId) {
-			if (form.data.autoProcess) {
-				locals.global.logger('imports').debug({
-					code: 'WEB_IMP_016',
-					title: 'Import created with auto-process - redirecting to import list',
-					userId: locals.user?.id,
-					importId: newId
-				});
-				redirect(302, urlGenerator({ address: '/(loggedIn)/import', searchParamsValue: {} }).url);
-			} else {
-				locals.global.logger('imports').debug({
-					code: 'WEB_IMP_017',
-					title: 'Import created without auto-process - redirecting to import detail',
-					userId: locals.user?.id,
-					importId: newId
-				});
-				redirect(
-					302,
-					urlGenerator({
-						address: '/(loggedIn)/import/[id]',
-						paramsValue: { id: newId }
-					}).url
-				);
-			}
-		}
-		return message(form, 'Unknown Error. Not Processed');
+		redirect(302, urlGenerator({ address: '/(loggedIn)/import', searchParamsValue: {} }).url);
 	}
 };

--- a/apps/webapp/src/routes/api/system/long-process/status/+server.ts
+++ b/apps/webapp/src/routes/api/system/long-process/status/+server.ts
@@ -1,14 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 
-import { getWriteLock, isWriteLockEnabled } from '$lib/server/longProcess/state';
+import { getLongProcessSnapshot } from '$lib/server/longProcess/state';
 
 export const GET: RequestHandler = async () => {
-	const lock = await getWriteLock();
-
-	return json({
-		writeLockEnabled: isWriteLockEnabled(),
-		locked: Boolean(lock),
-		lock
-	});
+	const snapshot = await getLongProcessSnapshot();
+	return json(snapshot);
 };

--- a/apps/webapp/src/routes/api/system/long-process/stream/+server.ts
+++ b/apps/webapp/src/routes/api/system/long-process/stream/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 
-import { getLongProcessEventsChannel, getWriteLock } from '$lib/server/longProcess/state';
+import { getLongProcessEventsChannel, getLongProcessSnapshot } from '$lib/server/longProcess/state';
 import { createRedisSubscriber } from '$lib/server/redis/redisClient';
 
 export const GET: RequestHandler = async () => {
@@ -27,8 +27,8 @@ export const GET: RequestHandler = async () => {
 				}
 			});
 
-			getWriteLock().then((lock) => {
-				sendEvent('snapshot', { lock });
+			getLongProcessSnapshot().then((snapshot) => {
+				sendEvent('snapshot', snapshot);
 			});
 
 			heartbeatInterval = setInterval(() => {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,12 @@
 		"@totallator/context": "workspace:*",
 		"@totallator/database": "workspace:*",
 		"@totallator/shared": "workspace:*",
-		"dotenv": "^17.2.3"
+		"dotenv": "^17.2.3",
+		"@aws-sdk/client-s3": "^3.978.0",
+		"@flystorage/aws-s3": "^1.2.0",
+		"@flystorage/file-storage": "^1.2.2",
+		"@flystorage/local-fs": "^1.2.0",
+		"ioredis": "^5.9.2"
 	},
 	"devDependencies": {
 		"@trivago/prettier-plugin-sort-imports": "^6.0.2",

--- a/apps/worker/src/bullmq/fileStaging.ts
+++ b/apps/worker/src/bullmq/fileStaging.ts
@@ -1,0 +1,63 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { AwsS3StorageAdapter } from '@flystorage/aws-s3';
+import { FileStorage } from '@flystorage/file-storage';
+import { LocalStorageAdapter } from '@flystorage/local-fs';
+
+import type { StagedFileData } from '@totallator/bullmq';
+
+import { workerEnv } from '../serverEnv';
+
+const STAGING_PREFIX = '__queue_staging';
+
+const getStorage = () => {
+	const address = workerEnv.IMPORT_DIR;
+
+	if (address.startsWith('s3://')) {
+		const bucketAndPrefix = address.replace('s3://', '');
+		const [bucket] = bucketAndPrefix.split('/');
+		if (!bucket) {
+			throw new Error('S3 bucket not correctly set');
+		}
+
+		const prefix = bucketAndPrefix.replace(`${bucket}/`, '');
+
+		if (
+			!workerEnv.S3_ACCESS_KEY_ID ||
+			!workerEnv.S3_SECRET_ACCESS_KEY ||
+			!workerEnv.S3_ACCESS_URL ||
+			!workerEnv.S3_REGION
+		) {
+			throw new Error('S3 environment variables not correctly set');
+		}
+
+		const client = new S3Client({
+			requestChecksumCalculation: workerEnv.S3_DISABLE_CHECKSUM
+				? 'WHEN_REQUIRED'
+				: 'WHEN_SUPPORTED',
+			responseChecksumValidation: workerEnv.S3_DISABLE_CHECKSUM
+				? 'WHEN_REQUIRED'
+				: 'WHEN_SUPPORTED',
+			credentials: {
+				accessKeyId: workerEnv.S3_ACCESS_KEY_ID,
+				secretAccessKey: workerEnv.S3_SECRET_ACCESS_KEY
+			},
+			endpoint: workerEnv.S3_ACCESS_URL,
+			region: workerEnv.S3_REGION
+		});
+
+		return new FileStorage(new AwsS3StorageAdapter(client, { bucket, prefix }));
+	}
+
+	return new FileStorage(new LocalStorageAdapter(address));
+};
+
+export const readStagedFile = async (file: StagedFileData) => {
+	const storage = getStorage();
+	const data = await storage.readToBuffer(file.storageKey);
+	return new File([data], file.originalName, { type: file.mimeType });
+};
+
+export const cleanupStagedFile = async (file: StagedFileData) => {
+	const storage = getStorage();
+	await storage.deleteFile(file.storageKey);
+};

--- a/apps/worker/src/bullmq/jobContracts.ts
+++ b/apps/worker/src/bullmq/jobContracts.ts
@@ -1,34 +1,5 @@
-import type { DefaultJobMap, JobResult } from '@totallator/bullmq';
-
-export const WORKER_QUEUES = {
-	CRON: 'cron',
-	BACKGROUND: 'background',
-	LONG_RUNNING: 'long-running'
-} as const;
-
-export type CronControlJobData =
-	| { action: 'trigger'; jobId: string; userId?: string }
-	| { action: 'toggle'; jobId: string; isEnabled: boolean; modifiedBy: string }
-	| { action: 'resync' };
-
-export type WorkerJobMap = DefaultJobMap & {
-	'test-log-job': {
-		data: {
-			message: string;
-		};
-		result: JobResult;
-	};
-	'cron-control': {
-		data: CronControlJobData;
-		result: JobResult;
-	};
-	'cron-execute': {
-		data: {
-			cronJobId: string;
-			triggeredBy?: 'scheduler' | 'manual' | 'api';
-			triggeredByUserId?: string;
-			retryCount?: number;
-		};
-		result: JobResult;
-	};
-};
+export { TOTALLATOR_QUEUES as WORKER_QUEUES } from '@totallator/bullmq';
+export type {
+	CronControlJobData,
+	TotallatorWorkerJobMap as WorkerJobMap
+} from '@totallator/bullmq';

--- a/apps/worker/src/bullmq/jobProcessors/longRunning.ts
+++ b/apps/worker/src/bullmq/jobProcessors/longRunning.ts
@@ -1,0 +1,525 @@
+import { workerRegistry } from '@totallator/bullmq';
+import type { TypedJobProcessor } from '@totallator/bullmq';
+import { tActions } from '@totallator/business-logic';
+
+import { standaloneContext } from '../../context/workerContext';
+import { runTrackedLongProcess } from '../../longProcess/state';
+import { cleanupStagedFile, readStagedFile } from '../fileStaging';
+import type { WorkerJobMap } from '../jobContracts';
+
+export const backupRestoreProcessor: TypedJobProcessor<WorkerJobMap, 'backup-restore'> = async (
+	job,
+	context
+) => {
+	const payload = job.data.data;
+
+	await runTrackedLongProcess({
+		type: 'backup-restore',
+		message: `Backup restore ${payload.backupId}`,
+		metadata: { backupId: payload.backupId },
+		maxRuntimeMs: 2 * 60 * 60 * 1000,
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-restore-${payload.backupId}`,
+					routeId: 'worker/backup/restore',
+					url: `/worker/backup/restore/${payload.backupId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.backup.restoreBackup({
+						id: payload.backupId,
+						includeUsers: payload.includeUsers ?? false,
+						userId: payload.userId
+					});
+				}
+			)
+	});
+
+	context.logger('worker').info({
+		title: 'Backup restore completed from BullMQ worker',
+		code: 'BULLMQ_WORKER_0004',
+		backupId: payload.backupId
+	});
+
+	return { success: true, data: { backupId: payload.backupId } };
+};
+
+export const backupStoreProcessor: TypedJobProcessor<WorkerJobMap, 'backup-store'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'backup-store',
+		message: 'Backup store',
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-store-${Date.now()}`,
+					routeId: 'worker/backup/store',
+					url: '/worker/backup/store',
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.backup.storeBackup(job.data.data);
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const backupRefreshProcessor: TypedJobProcessor<
+	WorkerJobMap,
+	'backup-refresh'
+> = async () => {
+	await runTrackedLongProcess({
+		type: 'backup-refresh',
+		message: 'Backup refresh',
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-refresh-${Date.now()}`,
+					routeId: 'worker/backup/refresh',
+					url: '/worker/backup/refresh',
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.backup.refreshList();
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const backupTrimProcessor: TypedJobProcessor<WorkerJobMap, 'backup-trim'> = async () => {
+	await runTrackedLongProcess({
+		type: 'backup-trim',
+		message: 'Backup trim',
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-trim-${Date.now()}`,
+					routeId: 'worker/backup/trim',
+					url: '/worker/backup/trim',
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.backup.trimBackups();
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const backupDeleteProcessor: TypedJobProcessor<WorkerJobMap, 'backup-delete'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'backup-delete',
+		message: `Backup delete ${job.data.data.backupId}`,
+		metadata: { backupId: job.data.data.backupId },
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-delete-${job.data.data.backupId}`,
+					routeId: 'worker/backup/delete',
+					url: `/worker/backup/delete/${job.data.data.backupId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.backup.deleteBackup({ id: job.data.data.backupId });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const backupImportProcessor: TypedJobProcessor<WorkerJobMap, 'backup-import'> = async (
+	job
+) => {
+	const payload = job.data.data;
+
+	await runTrackedLongProcess({
+		type: 'backup-import',
+		message: `Backup import ${payload.backupId}`,
+		metadata: { backupId: payload.backupId },
+		maxRuntimeMs: 2 * 60 * 60 * 1000,
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-backup-import-${payload.backupId}`,
+					routeId: 'worker/backup/import',
+					url: `/worker/backup/import/${payload.backupId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					const stagedFile = await readStagedFile(payload.file);
+					try {
+						await tActions.backup.importFile({ backupFile: stagedFile, id: payload.backupId });
+					} finally {
+						await cleanupStagedFile(payload.file);
+					}
+				}
+			)
+	});
+
+	return { success: true, data: { backupId: payload.backupId } };
+};
+
+export const autoImportTriggerProcessor: TypedJobProcessor<
+	WorkerJobMap,
+	'auto-import-trigger'
+> = async (job, context) => {
+	const payload = job.data.data;
+
+	await runTrackedLongProcess({
+		type: 'auto-import-trigger',
+		message: `Auto import ${payload.autoImportId}`,
+		metadata: { autoImportId: payload.autoImportId },
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-auto-import-${payload.autoImportId}`,
+					routeId: 'worker/auto-import/trigger',
+					url: `/worker/auto-import/trigger/${payload.autoImportId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.autoImport.trigger({ id: payload.autoImportId });
+				}
+			)
+	});
+
+	context.logger('worker').info({
+		title: 'Auto-import trigger completed from BullMQ worker',
+		code: 'BULLMQ_WORKER_0005',
+		autoImportId: payload.autoImportId,
+		triggeredByUserId: payload.triggeredByUserId
+	});
+
+	return { success: true, data: { autoImportId: payload.autoImportId } };
+};
+
+export const importStoreProcessor: TypedJobProcessor<WorkerJobMap, 'import-store'> = async (
+	job
+) => {
+	const payload = job.data.data;
+
+	await runTrackedLongProcess({
+		type: 'import-store',
+		message: 'Import store',
+		metadata: { importType: payload.importType, autoProcess: payload.autoProcess },
+		maxRuntimeMs: 3 * 60 * 60 * 1000,
+		run: async ({ reportProgress }) =>
+			standaloneContext(
+				{
+					requestId: `worker-import-store-${Date.now()}`,
+					routeId: 'worker/import/store',
+					url: '/worker/import/store',
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await reportProgress({ progress: 5, message: 'Preparing import file' });
+					const stagedFile = await readStagedFile(payload.file);
+					try {
+						await reportProgress({ progress: 20, message: 'Processing import file' });
+						await tActions.import.store({
+							autoImportId: payload.autoImportId,
+							data: {
+								importType: payload.importType,
+								importMappingId: payload.importMappingId,
+								autoProcess: payload.autoProcess,
+								autoClean: payload.autoClean,
+								checkImportedOnly: payload.checkImportedOnly,
+								file: stagedFile
+							}
+						});
+						await reportProgress({ progress: 90, message: 'Running post-import checks' });
+					} finally {
+						await cleanupStagedFile(payload.file);
+					}
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importReprocessProcessor: TypedJobProcessor<WorkerJobMap, 'import-reprocess'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'import-reprocess',
+		message: `Import reprocess ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		maxRuntimeMs: 2 * 60 * 60 * 1000,
+		run: async ({ reportProgress }) =>
+			standaloneContext(
+				{
+					requestId: `worker-import-reprocess-${job.data.data.importId}`,
+					routeId: 'worker/import/reprocess',
+					url: `/worker/import/reprocess/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await reportProgress({ progress: 20, message: 'Reprocessing import data' });
+					await tActions.import.reprocess({ id: job.data.data.importId });
+					await reportProgress({ progress: 90, message: 'Finalizing reprocess updates' });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importCleanProcessor: TypedJobProcessor<WorkerJobMap, 'import-clean'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'import-clean',
+		message: `Import clean ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		maxRuntimeMs: 2 * 60 * 60 * 1000,
+		run: async ({ reportProgress }) =>
+			standaloneContext(
+				{
+					requestId: `worker-import-clean-${job.data.data.importId}`,
+					routeId: 'worker/import/clean',
+					url: `/worker/import/clean/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await reportProgress({ progress: 25, message: 'Cleaning import records' });
+					await tActions.import.clean({ id: job.data.data.importId });
+					await reportProgress({ progress: 90, message: 'Applying cleanup updates' });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importTriggerProcessor: TypedJobProcessor<WorkerJobMap, 'import-trigger'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'import-trigger',
+		message: `Import trigger ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		maxRuntimeMs: 2 * 60 * 60 * 1000,
+		run: async ({ reportProgress }) =>
+			standaloneContext(
+				{
+					requestId: `worker-import-trigger-${job.data.data.importId}`,
+					routeId: 'worker/import/trigger',
+					url: `/worker/import/trigger/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await reportProgress({ progress: 20, message: 'Starting import processing' });
+					await tActions.import.triggerImport({ id: job.data.data.importId });
+					await reportProgress({ progress: 90, message: 'Running import validation and updates' });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importDeleteProcessor: TypedJobProcessor<WorkerJobMap, 'import-delete'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'import-delete',
+		message: `Import delete ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-import-delete-${job.data.data.importId}`,
+					routeId: 'worker/import/delete',
+					url: `/worker/import/delete/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.import.delete({ id: job.data.data.importId });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importDeleteLinkedProcessor: TypedJobProcessor<
+	WorkerJobMap,
+	'import-delete-linked'
+> = async (job) => {
+	await runTrackedLongProcess({
+		type: 'import-delete-linked',
+		message: `Import delete linked ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-import-delete-linked-${job.data.data.importId}`,
+					routeId: 'worker/import/delete-linked',
+					url: `/worker/import/delete-linked/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.import.deleteLinked({ id: job.data.data.importId });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const importForgetProcessor: TypedJobProcessor<WorkerJobMap, 'import-forget'> = async (
+	job
+) => {
+	await runTrackedLongProcess({
+		type: 'import-forget',
+		message: `Import forget ${job.data.data.importId}`,
+		metadata: { importId: job.data.data.importId },
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-import-forget-${job.data.data.importId}`,
+					routeId: 'worker/import/forget',
+					url: `/worker/import/forget/${job.data.data.importId}`,
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.import.forgetImport({ id: job.data.data.importId });
+				}
+			)
+	});
+	return { success: true };
+};
+
+export const fileCheckExistsProcessor: TypedJobProcessor<
+	WorkerJobMap,
+	'file-check-exists'
+> = async () => {
+	await runTrackedLongProcess({
+		type: 'file-check-exists',
+		message: 'File check exists',
+		run: async () =>
+			standaloneContext(
+				{
+					requestId: `worker-file-check-exists-${Date.now()}`,
+					routeId: 'worker/file/check-exists',
+					url: '/worker/file/check-exists',
+					method: 'WORKER',
+					startTime: Date.now(),
+					ip: '127.0.0.1'
+				},
+				async () => {
+					await tActions.file.checkFilesExist();
+				}
+			)
+	});
+	return { success: true };
+};
+
+workerRegistry.registerTyped<WorkerJobMap, 'backup-restore'>(
+	'backup-restore',
+	backupRestoreProcessor,
+	{
+		attempts: 1
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'backup-store'>('backup-store', backupStoreProcessor, {
+	attempts: 1
+});
+workerRegistry.registerTyped<WorkerJobMap, 'backup-refresh'>(
+	'backup-refresh',
+	backupRefreshProcessor,
+	{ attempts: 1 }
+);
+workerRegistry.registerTyped<WorkerJobMap, 'backup-trim'>('backup-trim', backupTrimProcessor, {
+	attempts: 1
+});
+workerRegistry.registerTyped<WorkerJobMap, 'backup-delete'>(
+	'backup-delete',
+	backupDeleteProcessor,
+	{
+		attempts: 1
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'backup-import'>(
+	'backup-import',
+	backupImportProcessor,
+	{
+		attempts: 1
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'auto-import-trigger'>(
+	'auto-import-trigger',
+	autoImportTriggerProcessor,
+	{ attempts: 3 }
+);
+workerRegistry.registerTyped<WorkerJobMap, 'import-store'>('import-store', importStoreProcessor, {
+	attempts: 1
+});
+workerRegistry.registerTyped<WorkerJobMap, 'import-reprocess'>(
+	'import-reprocess',
+	importReprocessProcessor,
+	{ attempts: 2 }
+);
+workerRegistry.registerTyped<WorkerJobMap, 'import-clean'>('import-clean', importCleanProcessor, {
+	attempts: 2
+});
+workerRegistry.registerTyped<WorkerJobMap, 'import-trigger'>(
+	'import-trigger',
+	importTriggerProcessor,
+	{
+		attempts: 2
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'import-delete'>(
+	'import-delete',
+	importDeleteProcessor,
+	{
+		attempts: 1
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'import-delete-linked'>(
+	'import-delete-linked',
+	importDeleteLinkedProcessor,
+	{ attempts: 1 }
+);
+workerRegistry.registerTyped<WorkerJobMap, 'import-forget'>(
+	'import-forget',
+	importForgetProcessor,
+	{
+		attempts: 1
+	}
+);
+workerRegistry.registerTyped<WorkerJobMap, 'file-check-exists'>(
+	'file-check-exists',
+	fileCheckExistsProcessor,
+	{ attempts: 1 }
+);

--- a/apps/worker/src/bullmq/workerService.ts
+++ b/apps/worker/src/bullmq/workerService.ts
@@ -1,5 +1,10 @@
 import { WorkerFactory } from '@totallator/bullmq';
+import {
+	clearInProgressBackupRestores,
+	initializeEventCallbacks
+} from '@totallator/business-logic';
 
+import { globalContext } from '../context/workerContext';
 import {
 	executeCronJobById,
 	setCronQueue,
@@ -9,6 +14,7 @@ import { workerEnv } from '../serverEnv';
 import { WORKER_QUEUES } from './jobContracts';
 import type { WorkerJobMap } from './jobContracts';
 import './jobProcessors/cronControl';
+import './jobProcessors/longRunning';
 import './jobProcessors/testJob';
 
 const createLogger = (category: string) => {
@@ -39,12 +45,17 @@ export const startWorkerService = async () => {
 		concurrency: 2
 	});
 
+	initializeEventCallbacks();
+	await clearInProgressBackupRestores();
+
 	const contextFactory = async () => {
+		const context = await globalContext();
+
 		return {
 			logger: createLogger,
-			db: {} as any,
+			db: context.db,
 			serverEnv: workerEnv,
-			getGlobalContext: undefined
+			getGlobalContext: async () => context
 		};
 	};
 

--- a/apps/worker/src/longProcess/state.ts
+++ b/apps/worker/src/longProcess/state.ts
@@ -1,0 +1,222 @@
+import IORedis from 'ioredis';
+import { nanoid } from 'nanoid';
+
+import { workerEnv } from '../serverEnv';
+
+const WRITE_LOCK_KEY = 'totallator:lock:global-write';
+const EVENTS_CHANNEL = 'totallator:events:jobs';
+const JOB_STATE_KEY_PREFIX = 'totallator:job:';
+
+export type WorkerLongProcessJobState = {
+	jobId: string;
+	type: string;
+	status: 'running' | 'completed' | 'failed' | 'cancelled';
+	progress: number;
+	message?: string;
+	startedAt: string;
+	updatedAt: string;
+	completedAt?: string;
+	metadata?: Record<string, unknown>;
+	error?: string;
+};
+
+const redis = new IORedis({
+	host: workerEnv.REDIS_HOST,
+	port: workerEnv.REDIS_PORT,
+	password: workerEnv.REDIS_PASSWORD,
+	db: workerEnv.REDIS_DB,
+	maxRetriesPerRequest: null,
+	enableReadyCheck: false,
+	lazyConnect: true
+});
+
+const getNow = () => new Date().toISOString();
+const getLockTTLSeconds = () => Math.max(workerEnv.LONG_PROCESS_LOCK_TTL_SECONDS, 15);
+const getJobStateKey = (jobId: string) => `${JOB_STATE_KEY_PREFIX}${jobId}:state`;
+
+class LongProcessTimeoutError extends Error {
+	constructor(type: string, timeoutMs: number) {
+		super(`Long process "${type}" exceeded timeout of ${timeoutMs}ms`);
+		this.name = 'LongProcessTimeoutError';
+	}
+}
+
+const DEFAULT_MAX_RUNTIME_MS = 60 * 60 * 1000;
+
+const publishEvent = async (event: string, payload: unknown) => {
+	await redis.publish(
+		EVENTS_CHANNEL,
+		JSON.stringify({
+			event,
+			payload,
+			timestamp: getNow()
+		})
+	);
+};
+
+const acquireWriteLock = async (jobId: string, type: string, reason?: string) => {
+	const now = Date.now();
+	const ttlSeconds = getLockTTLSeconds();
+	const lock = {
+		jobId,
+		type,
+		startedAt: new Date(now).toISOString(),
+		expiresAt: new Date(now + ttlSeconds * 1000).toISOString(),
+		reason,
+		owner: 'worker'
+	};
+
+	const result = await redis.set(WRITE_LOCK_KEY, JSON.stringify(lock), 'EX', ttlSeconds, 'NX');
+	if (result !== 'OK') {
+		return null;
+	}
+
+	await publishEvent('lock-acquired', lock);
+	return lock;
+};
+
+const refreshWriteLock = async (jobId: string, type: string, reason?: string) => {
+	const now = Date.now();
+	const ttlSeconds = getLockTTLSeconds();
+	const lock = {
+		jobId,
+		type,
+		startedAt: new Date(now).toISOString(),
+		expiresAt: new Date(now + ttlSeconds * 1000).toISOString(),
+		reason,
+		owner: 'worker'
+	};
+
+	await redis.set(WRITE_LOCK_KEY, JSON.stringify(lock), 'EX', ttlSeconds);
+	await publishEvent('lock-heartbeat', lock);
+};
+
+const releaseWriteLock = async (jobId: string) => {
+	const raw = await redis.get(WRITE_LOCK_KEY);
+	if (!raw) {
+		return;
+	}
+
+	try {
+		const lock = JSON.parse(raw);
+		if (lock.jobId !== jobId) {
+			return;
+		}
+		await redis.del(WRITE_LOCK_KEY);
+		await publishEvent('lock-released', lock);
+	} catch {
+		await redis.del(WRITE_LOCK_KEY);
+	}
+};
+
+export const runTrackedLongProcess = async <T>(params: {
+	type: string;
+	message: string;
+	metadata?: Record<string, unknown>;
+	reason?: string;
+	maxRuntimeMs?: number;
+	run: (context: {
+		jobId: string;
+		reportProgress: (params: {
+			progress: number;
+			message?: string;
+			metadata?: Record<string, unknown>;
+		}) => Promise<void>;
+	}) => Promise<T>;
+}) => {
+	const now = getNow();
+	const jobId = nanoid();
+
+	if (workerEnv.ENABLE_GLOBAL_WRITE_LOCK) {
+		const lock = await acquireWriteLock(jobId, params.type, params.reason);
+		if (!lock) {
+			throw new Error('Global write lock already active');
+		}
+	}
+
+	const state: WorkerLongProcessJobState = {
+		jobId,
+		type: params.type,
+		status: 'running',
+		progress: 0,
+		message: params.message,
+		startedAt: now,
+		updatedAt: now,
+		metadata: params.metadata
+	};
+
+	await redis.set(getJobStateKey(jobId), JSON.stringify(state), 'EX', 60 * 60 * 24);
+	await publishEvent('progress', state);
+
+	const reportProgress = async (update: {
+		progress: number;
+		message?: string;
+		metadata?: Record<string, unknown>;
+	}) => {
+		const updated: WorkerLongProcessJobState = {
+			...state,
+			status: 'running',
+			progress: Math.max(0, Math.min(100, update.progress)),
+			message: update.message ?? state.message,
+			metadata: update.metadata ?? state.metadata,
+			updatedAt: getNow()
+		};
+
+		await redis.set(getJobStateKey(jobId), JSON.stringify(updated), 'EX', 60 * 60 * 24);
+		await publishEvent('progress', updated);
+	};
+
+	let heartbeat: ReturnType<typeof setInterval> | null = null;
+	if (workerEnv.ENABLE_GLOBAL_WRITE_LOCK) {
+		heartbeat = setInterval(() => {
+			void refreshWriteLock(jobId, params.type, params.reason);
+		}, 10_000);
+	}
+
+	const maxRuntimeMs = Math.max(params.maxRuntimeMs ?? DEFAULT_MAX_RUNTIME_MS, 1_000);
+	let timeoutRef: ReturnType<typeof setTimeout> | null = null;
+
+	try {
+		const runPromise = params.run({ jobId, reportProgress });
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			timeoutRef = setTimeout(() => {
+				reject(new LongProcessTimeoutError(params.type, maxRuntimeMs));
+			}, maxRuntimeMs);
+		});
+
+		const result = await Promise.race([runPromise, timeoutPromise]);
+		const completed: WorkerLongProcessJobState = {
+			...state,
+			status: 'completed',
+			progress: 100,
+			message: `${params.message} completed`,
+			updatedAt: getNow(),
+			completedAt: getNow()
+		};
+		await redis.set(getJobStateKey(jobId), JSON.stringify(completed), 'EX', 60 * 60 * 24);
+		await publishEvent('completed', completed);
+		return result;
+	} catch (error) {
+		const failed: WorkerLongProcessJobState = {
+			...state,
+			status: 'failed',
+			message: `${params.message} failed`,
+			error: error instanceof Error ? error.message : 'Unknown error',
+			updatedAt: getNow(),
+			completedAt: getNow()
+		};
+		await redis.set(getJobStateKey(jobId), JSON.stringify(failed), 'EX', 60 * 60 * 24);
+		await publishEvent('failed', failed);
+		throw error;
+	} finally {
+		if (timeoutRef) {
+			clearTimeout(timeoutRef);
+		}
+		if (heartbeat) {
+			clearInterval(heartbeat);
+		}
+		if (workerEnv.ENABLE_GLOBAL_WRITE_LOCK) {
+			await releaseWriteLock(jobId);
+		}
+	}
+};

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -9,3 +9,6 @@ export * from "./workerFactory.js";
 
 // Export job definitions
 export * from "./jobDefinitions.js";
+
+// Export Totallator job contracts
+export * from "./totallatorJobContracts.js";

--- a/packages/bullmq/src/totallatorJobContracts.ts
+++ b/packages/bullmq/src/totallatorJobContracts.ts
@@ -1,0 +1,133 @@
+import type { DefaultJobMap, JobResult } from "./types.js";
+
+export const TOTALLATOR_QUEUES = {
+  CRON: "cron",
+  BACKGROUND: "background",
+  LONG_RUNNING: "long-running",
+} as const;
+
+export type CronControlJobData =
+  | { action: "trigger"; jobId: string; userId?: string }
+  | { action: "toggle"; jobId: string; isEnabled: boolean; modifiedBy: string }
+  | { action: "resync" };
+
+export type StagedFileData = {
+  storageKey: string;
+  originalName: string;
+  mimeType: string;
+};
+
+export type BackupRestoreJobData = {
+  backupId: string;
+  includeUsers?: boolean;
+  userId?: string;
+};
+
+export type BackupStoreJobData = {
+  title: string;
+  compress: boolean;
+  createdBy: string;
+  creationReason: string;
+};
+
+export type BackupImportJobData = {
+  backupId: string;
+  file: StagedFileData;
+};
+
+export type AutoImportTriggerJobData = {
+  autoImportId: string;
+  triggeredByUserId?: string;
+};
+
+export type ImportStoreJobData = {
+  importType: "flatImport" | "mappedImport";
+  importMappingId?: string;
+  autoProcess: boolean;
+  autoClean: boolean;
+  checkImportedOnly: boolean;
+  autoImportId?: string;
+  file: StagedFileData;
+};
+
+export type TotallatorWorkerJobMap = DefaultJobMap & {
+  "test-log-job": {
+    data: {
+      message: string;
+    };
+    result: JobResult;
+  };
+  "cron-control": {
+    data: CronControlJobData;
+    result: JobResult;
+  };
+  "cron-execute": {
+    data: {
+      cronJobId: string;
+      triggeredBy?: "scheduler" | "manual" | "api";
+      triggeredByUserId?: string;
+      retryCount?: number;
+    };
+    result: JobResult;
+  };
+  "backup-restore": {
+    data: BackupRestoreJobData;
+    result: JobResult;
+  };
+  "backup-store": {
+    data: BackupStoreJobData;
+    result: JobResult;
+  };
+  "backup-refresh": {
+    data: {};
+    result: JobResult;
+  };
+  "backup-trim": {
+    data: {};
+    result: JobResult;
+  };
+  "backup-import": {
+    data: BackupImportJobData;
+    result: JobResult;
+  };
+  "auto-import-trigger": {
+    data: AutoImportTriggerJobData;
+    result: JobResult;
+  };
+  "import-store": {
+    data: ImportStoreJobData;
+    result: JobResult;
+  };
+  "import-reprocess": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "import-clean": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "import-trigger": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "backup-delete": {
+    data: { backupId: string };
+    result: JobResult;
+  };
+  "import-delete": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "import-delete-linked": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "import-forget": {
+    data: { importId: string };
+    result: JobResult;
+  };
+  "file-check-exists": {
+    data: {};
+    result: JobResult;
+  };
+};

--- a/packages/bullmq/src/workerFactory.ts
+++ b/packages/bullmq/src/workerFactory.ts
@@ -1,4 +1,4 @@
-import { Queue, type QueueOptions, Worker } from "bullmq";
+import { Queue, type Job, type QueueOptions, Worker } from "bullmq";
 import IORedis from "ioredis";
 
 import type {
@@ -21,12 +21,15 @@ export interface WorkerFactoryConfig {
 }
 
 export type AddJobOptions = {
+  jobId?: string;
   delay?: number;
   repeat?: { pattern: string };
   priority?: number;
   attempts?: number;
   backoff?: string;
 };
+
+type QueueFactoryOptions = Omit<QueueOptions, "connection">;
 
 export class WorkerFactory {
   private workers: Map<string, Worker> = new Map();
@@ -55,8 +58,8 @@ export class WorkerFactory {
   ): Worker {
     const worker = new Worker(
       queueName,
-      async (job) => {
-        const { type, metadata } = job.data as JobData;
+      async (job: Job<JobData>) => {
+        const { type, metadata } = job.data;
         const processor = workerRegistry.getProcessor(type);
 
         if (!processor) {
@@ -87,15 +90,15 @@ export class WorkerFactory {
       },
     );
 
-    worker.on("completed", (job) => {
+    worker.on("completed", (job: Job<JobData>) => {
       console.log(`✅ Job ${job.id} (${job.data.type}) completed`);
     });
 
-    worker.on("failed", (job, err) => {
+    worker.on("failed", (job: Job<JobData> | undefined, err: Error) => {
       console.error(`❌ Job ${job?.id} (${job?.data?.type}) failed:`, err);
     });
 
-    worker.on("error", (err) => {
+    worker.on("error", (err: Error) => {
       console.error(`🚨 Worker error for ${queueName}:`, err);
     });
 
@@ -106,11 +109,11 @@ export class WorkerFactory {
   /**
    * Get queue instance
    */
-  getQueue(queueName: string, options: QueueOptions = {}): Queue {
+  getQueue(queueName: string, options: QueueFactoryOptions = {}): Queue {
     if (!this.queues.has(queueName)) {
       const queue = new Queue(queueName, {
-        connection: this.connection,
         ...options,
+        connection: this.connection,
       });
       this.queues.set(queueName, queue);
     }
@@ -139,6 +142,7 @@ export class WorkerFactory {
         type: options.backoff || "exponential",
         delay: 2000,
       },
+      jobId: options.jobId,
       delay: options.delay,
       repeat: options.repeat,
       priority: options.priority,


### PR DESCRIPTION
### Motivation

- Centralize job type definitions and queues so webapp and worker share a single contract for typed jobs and staged files.
- Offload long-running and background operations from synchronous web requests to BullMQ workers to improve responsiveness and reliability.
- Provide file staging (S3/local) so uploaded files can be handed off to workers safely and cleaned up afterwards.

### Description

- Added `packages/bullmq` exports including `totallatorJobContracts.ts` and re-exported them from the package index to expose `TOTALLATOR_QUEUES`, `StagedFileData`, and `TotallatorWorkerJobMap` types and constants.
- Replaced local job contract definitions in `apps/webapp` and `apps/worker` with exports from `@totallator/bullmq` and updated related imports to use `WEBAPP_QUEUES`/`WORKER_QUEUES` and typed `WorkerJobMap`.
- Implemented file staging utilities for `webapp` (`stageUploadedFile`) and `worker` (`readStagedFile`, `cleanupStagedFile`) supporting both S3 and local storage via `@flystorage` and `@aws-sdk/client-s3`.
- Converted many synchronous server route operations in `apps/webapp` to enqueue typed BullMQ jobs using `addTypedJob`, including cron controls, backup operations, import lifecycle (store, trigger, reprocess, clean, delete), auto-import triggers, and file checks.
- Added worker-side processors for long-running/background jobs in `apps/worker/src/bullmq/jobProcessors/longRunning.ts`, registering processors for backups, imports, auto-imports, and file checks, and integrated staged file read/cleanup in those processors.
- Added worker-side long process tracking (`apps/worker/src/longProcess/state.ts`) and updated webapp long-process endpoints to return aggregated snapshots (`getLongProcessSnapshot`) used by the stream and status APIs.
- Updated `WorkerFactory` in `packages/bullmq` to support passing `jobId` when adding jobs and improved typing around job handling.
- Updated `apps/worker` startup to initialize event callbacks, clear in-progress restores, and use a `globalContext` for worker processing, and added necessary dependencies to `apps/worker/package.json`.

### Testing

- Performed a TypeScript type-check of the modified packages with `tsc --noEmit` (workspace packages `apps/webapp`, `apps/worker`, and `packages/bullmq`) and the build/type checks completed successfully.
- No automated unit/integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aefda619f4832aa273aba053f6543d)